### PR TITLE
fix: use memfs instead of memory-fs

### DIFF
--- a/test-v3/package.json
+++ b/test-v3/package.json
@@ -6,14 +6,15 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "rootDir": ".",
-    "testMatch": ["<rootDir>/**/*.ts"]
+    "testMatch": [
+      "<rootDir>/**/*.ts"
+    ]
   },
   "dependencies": {
     "@babel/core": "^7.11.1",
     "@babel/preset-env": "^7.11.0",
-    "@types/memory-fs": "^0.3.2",
     "babel-loader": "^8.1.0",
-    "memory-fs": "^0.5.0",
+    "memfs": "^3.2.0",
     "uglifyjs-webpack-plugin": "^1.3.0",
     "webpack": "^3.12"
   },

--- a/test-v3/v3.test.ts
+++ b/test-v3/v3.test.ts
@@ -1,4 +1,5 @@
-import memoryfs from "memory-fs";
+import path from "path";
+import { createFsFromVolume, Volume } from "memfs";
 import licenseComment from "../fixtures/license";
 
 describe("webpack v3", () => {
@@ -7,7 +8,8 @@ describe("webpack v3", () => {
     const webpackConfig = require("./webpack.config.js");
     const expectedBanner = licenseComment();
     const compiler = webpack(webpackConfig);
-    compiler.outputFileSystem = new memoryfs();
+    compiler.outputFileSystem = createFsFromVolume(new Volume());
+    compiler.outputFileSystem.join = path.join.bind(path);
 
     compiler.run((err, stats) => {
       expect(err).toBeFalsy();

--- a/test-v3/yarn.lock
+++ b/test-v3/yarn.lock
@@ -1497,13 +1497,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
-"@types/memory-fs@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@types/memory-fs/-/memory-fs-0.3.2.tgz#5d4753f9b390cb077c8c8af97bc96463399ceccd"
-  integrity sha512-j5AcZo7dbMxHoOimcHEIh0JZe5e1b8q8AqGSpZJrYc7xOgCIP79cIjTdx5jSDLtySnQDwkDTqwlC7Xw7uXw7qg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
@@ -3172,6 +3165,11 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
+fs-monkey@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.1.tgz#4a82f36944365e619f4454d9fff106553067b781"
+  integrity sha512-fcSa+wyTqZa46iWweI7/ZiUfegOZl0SG8+dltIwFXo7+zYU9J9kpS3NB6pZcSlJdhvIwp81Adx2XhZorncxiaA==
+
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -4554,18 +4552,17 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memfs@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.0.tgz#f9438e622b5acd1daa8a4ae160c496fdd1325b26"
+  integrity sha512-f/xxz2TpdKv6uDn6GtHee8ivFyxwxmPuXatBb1FBwxYNuVpbM3k/Y1Z+vC0mH/dIXXrukYfe3qe5J32Dfjg93A==
+  dependencies:
+    fs-monkey "1.0.1"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
-  dependencies:
-    errno "^0.1.3"
-    readable-stream "^2.0.1"
-
-memory-fs@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.5.0.tgz#324c01288b88652966d161db77838720845a8e3c"
-  integrity sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"

--- a/test-v4/package.json
+++ b/test-v4/package.json
@@ -6,14 +6,15 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "rootDir": ".",
-    "testMatch": ["<rootDir>/**/*.ts"]
+    "testMatch": [
+      "<rootDir>/**/*.ts"
+    ]
   },
   "dependencies": {
     "@babel/core": "^7.11.1",
     "@babel/preset-env": "^7.11.0",
-    "@types/memory-fs": "^0.3.2",
     "babel-loader": "^8.1.0",
-    "memory-fs": "^0.5.0",
+    "memfs": "^3.2.0",
     "webpack": "^4.44.1"
   },
   "devDependencies": {

--- a/test-v4/v4.test.ts
+++ b/test-v4/v4.test.ts
@@ -1,4 +1,5 @@
-import memoryfs from "memory-fs";
+import path from "path";
+import { createFsFromVolume, Volume } from "memfs";
 import licenseComment from "../fixtures/license";
 
 describe("webpack v4", () => {
@@ -7,7 +8,8 @@ describe("webpack v4", () => {
     const webpackConfig = require("./webpack.config.js");
     const expectedBanner = licenseComment();
     const compiler = webpack(webpackConfig);
-    compiler.outputFileSystem = new memoryfs();
+    compiler.outputFileSystem = createFsFromVolume(new Volume());
+    compiler.outputFileSystem.join = path.join.bind(path);
 
     compiler.run((err, stats) => {
       expect(err).toBeFalsy();

--- a/test-v4/yarn.lock
+++ b/test-v4/yarn.lock
@@ -1497,13 +1497,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
-"@types/memory-fs@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@types/memory-fs/-/memory-fs-0.3.2.tgz#5d4753f9b390cb077c8c8af97bc96463399ceccd"
-  integrity sha512-j5AcZo7dbMxHoOimcHEIh0JZe5e1b8q8AqGSpZJrYc7xOgCIP79cIjTdx5jSDLtySnQDwkDTqwlC7Xw7uXw7qg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
@@ -3141,6 +3134,11 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-monkey@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.1.tgz#4a82f36944365e619f4454d9fff106553067b781"
+  integrity sha512-fcSa+wyTqZa46iWweI7/ZiUfegOZl0SG8+dltIwFXo7+zYU9J9kpS3NB6pZcSlJdhvIwp81Adx2XhZorncxiaA==
+
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -4405,6 +4403,13 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+memfs@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.0.tgz#f9438e622b5acd1daa8a4ae160c496fdd1325b26"
+  integrity sha512-f/xxz2TpdKv6uDn6GtHee8ivFyxwxmPuXatBb1FBwxYNuVpbM3k/Y1Z+vC0mH/dIXXrukYfe3qe5J32Dfjg93A==
+  dependencies:
+    fs-monkey "1.0.1"
 
 memory-fs@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
memory-fs is deprecated

- https://github.com/webpack/webpack/commit/e1ec9e6bea57a8649d552116d6c4e8a193b7ab2a
- https://github.com/webpack/webpack.js.org/pull/3723/files#r418683319
